### PR TITLE
Fix "bash: warning: here-document at line 19 delimited by end-of-file…

### DIFF
--- a/version_control/.aliases.sh
+++ b/version_control/.aliases.sh
@@ -63,7 +63,8 @@ for i, _ in enumerate(dirs):
     else:
         print filename
         break
-EOF)
+EOF
+)
     if [[ -z "${filename}" ]]; then
         echo ".git/config not found"
     else


### PR DESCRIPTION
… (wanted `EOF')"